### PR TITLE
Update AppServiceProvider.php

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -28,7 +28,7 @@ class AppServiceProvider extends ServiceProvider
 
         // View composer for tags
         view()->composer('partials._tags', function($view){
-            $tags_sidebar = \App\Models\Tag::withCount('posts')->orderBy('posts_count', 'desc')->orderBy('name')->get()->take(5);
+            $tags_sidebar = \App\Models\Tag::withCount('posts')->orderBy('posts_count', 'desc')->orderBy('name')->take(5)->get();
 
             $view->with(compact('tags_sidebar'));
         }); 


### PR DESCRIPTION
A take() megelőzi a get()-et lekérdezésnél. Ha jól tudom, ha nem jó sorrendben adod meg, az azt eredményezi hogy lekéri az összes rekordot és kiszed belőle neked 5-öt, azonban nekünk már a lekérdezésnél jobb lenne, ha csak 5-öt szedne.